### PR TITLE
Enlace repetido

### DIFF
--- a/es_ES/get-started/learn-more.md
+++ b/es_ES/get-started/learn-more.md
@@ -13,7 +13,6 @@ Aprender más acerca del framework de Flutter:
 * [Contruyendo Layouts en Flutter](/tutorials/layout/) tutorial
 * [Agregar Interactividad](/tutorials/interactive/) tutorial
 * [Un Tour de widgets en Flutter](/widgets-intro/)
-* [Flutter para desarrolladores de Android](/flutter-for-android/)
 
 Otras fuentes:
 


### PR DESCRIPTION
El primer enlace es el mismo que el eliminado
tomado de flutter/webiste commit 1144 https://github.com/flutter/website/commit/ae834aea7a339c524dd8984fbebab6d02a2dd728#diff-59589b945949a6640f6ce6d463477899